### PR TITLE
Add Teleoperate Mode Closes:  #31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ serde = { version = "*", features = ["derive"] }
 serde_derive = "*"
 termion = "1.5"
 tui = "0.10.0"
+strum = "0.23"
+strum_macros = "0.23"
 
 [dependencies.confy]
 version = "0.4.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use nalgebra::{Isometry2, Vector2};
 use std::convert::TryFrom;
 use std::io;
 use std::sync::Arc;
+use strum_macros::AsRefStr;
 use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::raw::RawTerminal;
@@ -18,13 +19,14 @@ use tui::style::{Color, Modifier, Style};
 use tui::text::{Span, Spans};
 use tui::widgets::canvas::{Canvas, Line, Points};
 use tui::widgets::{Block, Borders, Paragraph, Row, Table, Wrap};
-use tui::Frame;
-use tui::Terminal;
+use tui::{Frame, Terminal};
 
+#[derive(PartialEq, AsRefStr)]
 pub enum AppModes {
     RobotView,
     SendPose,
     HelpPage,
+    Teleoperate,
 }
 
 pub fn get_frame_lines(tf: &rosrust_msg::geometry_msgs::Transform, axis_length: f64) -> Vec<Line> {
@@ -164,6 +166,7 @@ impl App {
             ["a", "Shifts the pose estimate negatively along the y axis."],
             ["q", "Rotates the pose estimate counter-clockwise."],
             ["e", "Rotates the pose estimate clockwise."],
+            ["t", "Enter/Exit teleoperating mode"],
             ["Esc", "Resets the pose estimate."],
             ["Enter", "Sends the pose estimate."],
             ["-", "Decreases the zoom."],
@@ -185,6 +188,10 @@ impl App {
             "Welcome to TermViz!",
             "",
             "To get started, take a look at the configuration file, which is located in ~/.config/termviz/termviz.yml.",
+            "",
+            "Press 't' to enter/exit teleoperating mode, where the configured keys (default wasd qe) are used to move the robot. \
+            When entering the mode, a zero velocity vector is sent, stopping the robot. \
+            Additionally, any button but the configured ones will stop the robot",
             "",
             "Press any key to go back to the robot view, or Ctrl+c to exit.",
             "", // Leave some space to the bottom
@@ -270,7 +277,7 @@ impl App {
         let canvas = Canvas::default()
             .block(
                 Block::default()
-                    .title(format!("Robot View - Press h for help"))
+                    .title(format!("{} - Press h for help", self.mode.as_ref()))
                     .borders(Borders::NONE),
             )
             .x_bounds([self.bounds[0], self.bounds[1]])

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use confy;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Color {
@@ -15,6 +16,31 @@ pub struct ListenerConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct TeleopConfig {
+    pub key_mapping: HashMap<String, (String, i8)>,
+    pub increment: f64,
+    pub cmd_vel_topic: String,
+}
+
+impl Default for TeleopConfig {
+    fn default() -> TeleopConfig {
+        let default_mapping = HashMap::from([
+            ("w".to_string(), ("x".to_string(), 1)),
+            ("s".to_string(), ("x".to_string(), -1)),
+            ("q".to_string(), ("y".to_string(), 1)),
+            ("e".to_string(), ("y".to_string(), -1)),
+            ("a".to_string(), ("theta".to_string(), 1)),
+            ("d".to_string(), ("theta".to_string(), -1)),
+        ]);
+        TeleopConfig {
+            key_mapping: default_mapping,
+            increment: 0.1,
+            cmd_vel_topic: "cmd_vel".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TermvizConfig {
     pub fixed_frame: String,
     pub robot_frame: String,
@@ -25,6 +51,7 @@ pub struct TermvizConfig {
     pub axis_length: f64,
     pub visible_area: Vec<f64>, //Borders of map from center in Meter
     pub zoom_factor: f64,
+    pub teleop_key_mapping: TeleopConfig,
 }
 
 impl Default for TermvizConfig {
@@ -56,6 +83,7 @@ impl Default for TermvizConfig {
             axis_length: 0.5,
             visible_area: vec![-5., 5., -5., 5.],
             zoom_factor: 0.1,
+            teleop_key_mapping: TeleopConfig::default(),
         };
         let res = confy::store("termviz", "termviz", &conf);
         match res {

--- a/src/teleop.rs
+++ b/src/teleop.rs
@@ -1,0 +1,70 @@
+use crate::config::TeleopConfig;
+use rosrust;
+use rosrust_msg;
+use std::collections::HashMap;
+use termion::event::Key;
+
+pub struct Teleoperator {
+    current_velocities: Velocities,
+    _cmd_val_pub: rosrust::Publisher<rosrust_msg::geometry_msgs::Twist>,
+    _keys_to_direction: HashMap<Key, (String, i8)>,
+    _increment: f64,
+}
+
+pub struct Velocities {
+    x: f64,
+    y: f64,
+    theta: f64,
+}
+
+impl Teleoperator {
+    pub fn new(config: TeleopConfig) -> Teleoperator {
+        let cmd_val_publisher = rosrust::publish(&config.cmd_vel_topic, 1).unwrap();
+        let initial_velocities = Velocities {
+            x: 0.,
+            y: 0.,
+            theta: 0.,
+        };
+        Teleoperator {
+            _cmd_val_pub: cmd_val_publisher,
+            current_velocities: initial_velocities,
+            // Map strings to Key::Char
+            _keys_to_direction: config
+                .key_mapping
+                .iter()
+                .map(|(k, v)| (Key::Char(k.chars().next().unwrap()), v.clone()))
+                .collect(),
+            _increment: config.increment.clone(),
+        }
+    }
+
+    pub fn handle_input_from_key(&mut self, input: Key) {
+        if !self._keys_to_direction.contains_key(&input) {
+            self.reset();
+            return;
+        }
+        let (coordinate, direction) = self._keys_to_direction[&input].clone();
+        match coordinate.as_ref() {
+            "x" => self.current_velocities.x += direction as f64 * self._increment,
+            "y" => self.current_velocities.y += direction as f64 * self._increment,
+            "theta" => self.current_velocities.theta += direction as f64 * self._increment,
+            _ => println!("{} is not supported!", coordinate),
+        }
+    }
+
+    pub fn run(&mut self) {
+        let mut vel_cmd = rosrust_msg::geometry_msgs::Twist::default();
+        vel_cmd.linear.x = self.current_velocities.x;
+        vel_cmd.linear.y = self.current_velocities.y;
+        vel_cmd.angular.z = self.current_velocities.theta;
+        self._cmd_val_pub.send(vel_cmd).unwrap();
+    }
+
+    pub fn reset(&mut self) {
+        self.current_velocities = Velocities {
+            x: 0.,
+            y: 0.,
+            theta: 0.,
+        };
+    }
+}


### PR DESCRIPTION
What this does:
when 't' is pressed, it starts teleoperating mode publishing command val.
You can increment/decrement with the keys in config - currently only normal chars are supported (no arrow keys)
when any other key is pressed, the velocities are reset (use pushes any keys because he teleoped by accident)

I think we can have this as a Prototype and improve it to keep the PRs a bit smaller:

1. Have a visual feedback e.g. make backround red / display cmd_vel
2. support arrow keys
3. 'safe' mode, e.g. shut off when a button is NOT pressed (could be annoying to use)
