### PR TITLE
Add image subscribers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,13 @@ exclude = ["assets/*", ".github"]
 
 
 [dependencies]
+byteorder = "*"
+image = "*"
 nalgebra = ">=0.29.0"
 rosrust = "0.9"
 rosrust_msg = "0.1"
 rustros_tf = { git = "https://github.com/maximaerz/rustros_tf" }
+tui-image = { git = "https://github.com/carzum/tui-image" }
 serde = { version = "*", features = ["derive"] }
 serde_derive = "*"
 termion = "1.5"

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,7 @@ pub struct TermvizConfig {
     pub map_topics: Vec<ListenerConfigColor>,
     pub laser_topics: Vec<ListenerConfigColor>,
     pub marker_topics: Vec<ListenerConfig>,
+    pub image_topics: Vec<ListenerConfig>,
     pub marker_array_topics: Vec<ListenerConfig>,
     pub target_framerate: i64,
     pub axis_length: f64,
@@ -82,6 +83,9 @@ impl Default for TermvizConfig {
             }],
             marker_topics: vec![ListenerConfig {
                 topic: "marker".to_string(),
+            }],
+            image_topics: vec![ListenerConfig {
+                topic: "image_rect".to_string(),
             }],
             target_framerate: 30,
             axis_length: 0.5,

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,0 +1,116 @@
+use crate::config::ListenerConfig;
+use byteorder::{ByteOrder, LittleEndian};
+use image::{DynamicImage, ImageBuffer, RgbaImage};
+use rosrust;
+use rosrust_msg;
+use std::sync::{Arc, RwLock};
+
+// remap a value from range min_val - max_val to 0 - 255
+fn remap_u8(val: f64, min_val: f64, max_val: f64) -> u8 {
+    ((val - min_val) * (u8::MAX as f64 / (max_val - min_val))) as u8
+}
+
+fn read_img_msg(img_msg: rosrust_msg::sensor_msgs::Image) -> DynamicImage {
+    match img_msg.encoding.as_ref() {
+        "8UC1" | "mono8" => DynamicImage::ImageLuma8(
+            ImageBuffer::from_raw(img_msg.width, img_msg.height, img_msg.data).unwrap(),
+        ),
+        "8UC3" | "rgb8" => DynamicImage::ImageRgb8(
+            ImageBuffer::from_raw(img_msg.width, img_msg.height, img_msg.data).unwrap(),
+        ),
+        "16UC1" | "mono16" => DynamicImage::ImageLuma8(
+            ImageBuffer::from_raw(img_msg.width, img_msg.height, read_u16(&img_msg.data)).unwrap(),
+        ),
+        "32FC1" => DynamicImage::ImageLuma8(
+            ImageBuffer::from_raw(img_msg.width, img_msg.height, read_f32(&img_msg.data)).unwrap(),
+        ),
+        _ => panic!("Image encoding {:?} not supported", img_msg.encoding),
+    }
+}
+
+fn read_f32(vec: &Vec<u8>) -> Vec<u8> {
+    let mut vals: Vec<f32> = Vec::with_capacity(vec.len() / 4);
+    let mut max_val = f32::MIN;
+    let mut min_val = f32::MAX;
+    for elem in vec.chunks(4) {
+        let val = LittleEndian::read_f32(&elem);
+        vals.push(val);
+        if val > max_val {
+            max_val = val;
+        }
+        if val < min_val {
+            min_val = val;
+        }
+    }
+    let mut bytes: Vec<u8> = Vec::with_capacity(vals.len());
+    for val in vals {
+        bytes.push(remap_u8(val as f64, min_val as f64, max_val as f64));
+    }
+    bytes
+}
+
+fn read_u16(vec: &Vec<u8>) -> Vec<u8> {
+    let mut vals: Vec<u16> = Vec::with_capacity(vec.len() / 2);
+    let mut max_val = u16::MIN;
+    let mut min_val = u16::MAX;
+    for elem in vec.chunks(2) {
+        let val = LittleEndian::read_u16(&elem);
+        vals.push(val);
+        if val > max_val {
+            max_val = val;
+        }
+        if val < min_val {
+            min_val = val;
+        }
+    }
+    let mut bytes: Vec<u8> = Vec::with_capacity(vals.len());
+    for val in vals {
+        bytes.push(remap_u8(val as f64, min_val as f64, max_val as f64));
+    }
+    bytes
+}
+
+pub struct ImageListener {
+    pub config: ListenerConfig,
+    pub img: Arc<RwLock<RgbaImage>>,
+    _subscriber: Option<rosrust::Subscriber>,
+}
+
+impl ImageListener {
+    pub fn new(config: ListenerConfig) -> ImageListener {
+        let img = Arc::new(RwLock::new(RgbaImage::new(0, 0)));
+
+        ImageListener {
+            config,
+            img,
+            _subscriber: None,
+        }
+    }
+
+    pub fn setup_sub(&mut self) {
+        let cb_img = self.img.clone();
+        let sub = rosrust::subscribe(
+            &self.config.topic,
+            1,
+            move |img_msg: rosrust_msg::sensor_msgs::Image| {
+                let img = read_img_msg(img_msg);
+                let mut cb_img = cb_img.write().unwrap();
+                *cb_img = img.to_rgba8();
+            },
+        )
+        .unwrap();
+        self._subscriber = Some(sub)
+    }
+
+    pub fn is_active(&self) -> bool {
+        self._subscriber.is_some()
+    }
+
+    pub fn activate(&mut self) {
+        self.setup_sub();
+    }
+
+    pub fn deactivate(&mut self) {
+        self._subscriber = None;
+    }
+}

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -2,6 +2,7 @@ use crate::config::{ListenerConfig, ListenerConfigColor};
 use crate::laser;
 use crate::map;
 use crate::marker;
+use crate::image;
 
 use std::sync::Arc;
 
@@ -10,6 +11,7 @@ pub struct Listeners {
     pub markers: Vec<marker::MarkerListener>,
     pub marker_arrays: Vec<marker::MarkerArrayListener>,
     pub maps: Vec<map::MapListener>,
+    pub images: Vec<image::ImageListener>,
 }
 
 impl Listeners {
@@ -20,6 +22,7 @@ impl Listeners {
         marker_topics: Vec<ListenerConfig>,
         marker_array_topics: Vec<ListenerConfig>,
         map_topics: Vec<ListenerConfigColor>,
+        image_topics: Vec<ListenerConfig>,
     ) -> Listeners {
         let mut lasers: Vec<laser::LaserListener> = Vec::new();
         for laser_config in laser_topics {
@@ -58,11 +61,17 @@ impl Listeners {
             ));
         }
 
+        let mut images: Vec<image::ImageListener> = Vec::new();
+        for image_config in image_topics {
+            images.push(image::ImageListener::new(image_config));
+        }
+
         Listeners {
             lasers,
             markers,
             marker_arrays,
             maps,
+            images
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod config;
 mod event;
 mod footprint;
+mod image;
 mod initial_pose;
 mod laser;
 mod listeners;
@@ -83,6 +84,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                                     running_app.mode = app::AppModes::SendPose;
                                     running_app.move_pose_estimate(0.0, 0.0, distance);
                                 }
+                            }
+                            Key::Char('i') => {
+                                running_app.mode = app::AppModes::ImageView;
+                                running_app.activate_next_image_sub();
                             }
                             Key::Char('e') => {
                                 if running_app.mode != app::AppModes::Teleoperate {
@@ -169,6 +174,26 @@ fn main() -> Result<(), Box<dyn Error>> {
                             break;
                         }
                         _ => {
+                            running_app.mode = app::AppModes::RobotView;
+                        }
+                    },
+                    Event::Tick => {}
+                }
+            }
+            app::AppModes::ImageView => {
+                terminal.draw(|f| {
+                    running_app.draw_image(f);
+                })?;
+                match events.next()? {
+                    Event::Input(input) => match input {
+                        Key::Ctrl('c') => {
+                            break;
+                        }
+                        Key::Char('i') => {
+                            running_app.activate_next_image_sub();
+                        }
+                        _ => {
+                            running_app.deactivate_image_subs();
                             running_app.mode = app::AppModes::RobotView;
                         }
                     },


### PR DESCRIPTION
press i to enter image mode, it will cycle between  subscribers when pressing i again. 
I only implemented conversions for a few common image formats for now. 
The subscriber callback is quite inefficient, thus subscriber call backs do nothing when the subscriber is not active.
It is pretty quick on my machine when listening to streams with moderate resolution / framerate when compiled with --release. Please yell if you find it too sluggish