### PR TITLE
Split ListenerConfig

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,11 @@ pub struct Color {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListenerConfig {
     pub topic: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListenerConfigColor {
+    pub topic: String,
     pub color: Color,
 }
 
@@ -44,8 +49,8 @@ impl Default for TeleopConfig {
 pub struct TermvizConfig {
     pub fixed_frame: String,
     pub robot_frame: String,
-    pub map_topics: Vec<ListenerConfig>,
-    pub laser_topics: Vec<ListenerConfig>,
+    pub map_topics: Vec<ListenerConfigColor>,
+    pub laser_topics: Vec<ListenerConfigColor>,
     pub marker_topics: Vec<ListenerConfig>,
     pub marker_array_topics: Vec<ListenerConfig>,
     pub target_framerate: i64,
@@ -60,7 +65,7 @@ impl Default for TermvizConfig {
         let conf = TermvizConfig {
             fixed_frame: "map".to_string(),
             robot_frame: "base_link".to_string(),
-            map_topics: vec![ListenerConfig {
+            map_topics: vec![ListenerConfigColor {
                 topic: "map".to_string(),
                 color: Color {
                     r: 255,
@@ -68,25 +73,15 @@ impl Default for TermvizConfig {
                     g: 255,
                 },
             }],
-            laser_topics: vec![ListenerConfig {
+            laser_topics: vec![ListenerConfigColor {
                 topic: "scan".to_string(),
                 color: Color { r: 200, b: 0, g: 0 },
             }],
             marker_array_topics: vec![ListenerConfig {
                 topic: "marker_array".to_string(),
-                color: Color {
-                    r: 20,
-                    b: 20,
-                    g: 200,
-                },
             }],
             marker_topics: vec![ListenerConfig {
                 topic: "marker".to_string(),
-                color: Color {
-                    r: 20,
-                    b: 20,
-                    g: 200,
-                },
             }],
             target_framerate: 30,
             axis_length: 0.5,

--- a/src/laser.rs
+++ b/src/laser.rs
@@ -1,4 +1,4 @@
-use crate::config::ListenerConfig;
+use crate::config::ListenerConfigColor;
 use crate::transformation;
 use std::sync::{Arc, RwLock};
 
@@ -6,7 +6,7 @@ use rosrust;
 use rustros_tf;
 
 pub struct LaserListener {
-    pub config: ListenerConfig,
+    pub config: ListenerConfigColor,
     pub points: Arc<RwLock<Vec<(f64, f64)>>>,
     _tf_listener: Arc<rustros_tf::TfListener>,
     _static_frame: String,
@@ -15,7 +15,7 @@ pub struct LaserListener {
 
 impl LaserListener {
     pub fn new(
-        config: ListenerConfig,
+        config: ListenerConfigColor,
         tf_listener: Arc<rustros_tf::TfListener>,
         static_frame: String,
     ) -> LaserListener {

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -1,4 +1,4 @@
-use crate::config::ListenerConfig;
+use crate::config::{ListenerConfig, ListenerConfigColor};
 use crate::laser;
 use crate::map;
 use crate::marker;
@@ -16,10 +16,10 @@ impl Listeners {
     pub fn new(
         tf_listener: Arc<rustros_tf::TfListener>,
         static_frame: String,
-        laser_topics: Vec<ListenerConfig>,
+        laser_topics: Vec<ListenerConfigColor>,
         marker_topics: Vec<ListenerConfig>,
         marker_array_topics: Vec<ListenerConfig>,
-        map_topics: Vec<ListenerConfig>,
+        map_topics: Vec<ListenerConfigColor>,
     ) -> Listeners {
         let mut lasers: Vec<laser::LaserListener> = Vec::new();
         for laser_config in laser_topics {

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,4 +1,4 @@
-use crate::config::ListenerConfig;
+use crate::config::ListenerConfigColor;
 use crate::transformation;
 use std::sync::{Arc, RwLock};
 
@@ -8,7 +8,7 @@ use rosrust;
 use rustros_tf;
 
 pub struct MapListener {
-    pub config: ListenerConfig,
+    pub config: ListenerConfigColor,
     pub points: Arc<RwLock<Vec<(f64, f64)>>>,
     _tf_listener: Arc<rustros_tf::TfListener>,
     _static_frame: String,
@@ -17,7 +17,7 @@ pub struct MapListener {
 
 impl MapListener {
     pub fn new(
-        config: ListenerConfig,
+        config: ListenerConfigColor,
         tf_listener: Arc<rustros_tf::TfListener>,
         static_frame: String,
     ) -> MapListener {


### PR DESCRIPTION
Some Listeners, like Marker, MarkerArray or images do not need colors, split ListinerConfig in ListenerConfigColor and ListenerConfig to avoid bogus colors