### PR TITLE
Xb32z/improve markers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["assets/*", ".github"]
 
 [dependencies]
 byteorder = "*"
-chrono = "*"
+chrono = "0.2.25"
 image = "*"
 nalgebra = ">=0.29.0"
 rosrust = "0.9"
@@ -19,7 +19,7 @@ tui-image = { git = "https://github.com/carzum/tui-image" }
 serde = { version = "*", features = ["derive"] }
 serde_derive = "*"
 termion = "1.5"
-timer = "*"
+timer = "0.1.6"
 tui = "0.16.0"
 strum = "0.23"
 strum_macros = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ exclude = ["assets/*", ".github"]
 
 [dependencies]
 byteorder = "*"
+chrono = "*"
 image = "*"
 nalgebra = ">=0.29.0"
 rosrust = "0.9"
@@ -18,6 +19,7 @@ tui-image = { git = "https://github.com/carzum/tui-image" }
 serde = { version = "*", features = ["derive"] }
 serde_derive = "*"
 termion = "1.5"
+timer = "*"
 tui = "0.16.0"
 strum = "0.23"
 strum_macros = "0.23"

--- a/src/app.rs
+++ b/src/app.rs
@@ -355,15 +355,9 @@ impl App {
                         ),
                     });
                 }
-                for marker in &self.listeners.markers {
-                    for line in marker.get_lines() {
-                        ctx.draw(&line);
-                    }
-                }
-                for marker_array in &self.listeners.marker_arrays {
-                    for line in marker_array.get_lines() {
-                        ctx.draw(&line);
-                    }
+
+                for line in self.listeners.markers.get_lines() {
+                    ctx.draw(&line);
                 }
 
                 for line in get_frame_lines(&base_link_pose, self.axis_length) {

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -1,15 +1,14 @@
 use crate::config::{ListenerConfig, ListenerConfigColor};
+use crate::image;
 use crate::laser;
 use crate::map;
 use crate::marker;
-use crate::image;
 
 use std::sync::Arc;
 
 pub struct Listeners {
     pub lasers: Vec<laser::LaserListener>,
-    pub markers: Vec<marker::MarkerListener>,
-    pub marker_arrays: Vec<marker::MarkerArrayListener>,
+    pub markers: marker::MarkersListener,
     pub maps: Vec<map::MapListener>,
     pub images: Vec<image::ImageListener>,
 }
@@ -33,24 +32,14 @@ impl Listeners {
             ));
         }
 
-        let mut markers: Vec<marker::MarkerListener> = Vec::new();
+        let mut markers = marker::MarkersListener::new(tf_listener.clone(), static_frame.clone());
         for marker_config in marker_topics {
-            markers.push(marker::MarkerListener::new(
-                marker_config,
-                tf_listener.clone(),
-                static_frame.clone(),
-            ));
+            markers.add_marker_listener(&marker_config);
         }
 
-        let mut marker_arrays: Vec<marker::MarkerArrayListener> = Vec::new();
         for m_config in marker_array_topics {
-            marker_arrays.push(marker::MarkerArrayListener::new(
-                m_config,
-                tf_listener.clone(),
-                static_frame.clone(),
-            ));
+            markers.add_marker_array_listener(&m_config);
         }
-
 
         let mut maps: Vec<map::MapListener> = Vec::new();
         for map_config in map_topics {
@@ -69,9 +58,8 @@ impl Listeners {
         Listeners {
             lasers,
             markers,
-            marker_arrays,
             maps,
-            images
+            images,
         }
     }
 }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1,5 +1,13 @@
+//! Module dealing with the reception, projection and lifecycle of visualization markers.
+//!
+//! ROS has a type of message dedicated to visualization: visualization_msgs::Marker.
+//! This module allows to subsribe to topics that publish them and project them into the
+//! 2D plane. Finally, it takes care of their lifecycle: ADD, DELETE and timeout.
 use crate::config::ListenerConfig;
-use std::sync::{Arc, RwLock};
+use nalgebra::geometry::Isometry3;
+use std::collections::BTreeMap;
+use std::f64::consts::PI;
+use std::sync::{Arc, Mutex, RwLock};
 
 use rosrust;
 use rustros_tf::transforms::nalgebra::geometry::Point3;
@@ -8,12 +16,264 @@ use rustros_tf::transforms::{isometry_from_pose, isometry_from_transform};
 use tui::style::Color;
 use tui::widgets::canvas::Line;
 
-pub fn marker_2_rectancle(
+struct TermvizMarker {
+    pub lines: Vec<Line>,
+    pub id: i32,
+    pub ns: String,
+}
+
+///Creates a list of lines from N line stips.
+/// Arguments:
+/// - `strips`: A vector of vector of points. Each element is a strip, i.e. a single
+///             broken line. Each strip has N points that form N-1 lines.
+fn from_point_strips(strips: &Vec<Vec<Point3<f64>>>, color: &Color) -> Vec<Line> {
+    let mut lines: Vec<Line> = Vec::new();
+
+    for strip in strips {
+        let mut previous_point: Option<&Point3<f64>> = None;
+        for point in strip {
+            if previous_point.is_some() {
+                let pp = previous_point.unwrap();
+                lines.push(Line {
+                    x1: pp.x,
+                    y1: pp.y,
+                    x2: point.x,
+                    y2: point.y,
+                    color: *color,
+                });
+            }
+            previous_point = Some(point);
+        }
+    }
+
+    lines
+}
+
+fn parse_cube(
+    dimension: &rosrust_msg::geometry_msgs::Vector3,
+    offset: &rosrust_msg::geometry_msgs::Point,
+    color: &tui::style::Color,
+    iso: &Isometry3<f64>,
+) -> Vec<Line> {
+    let angles = iso.rotation.euler_angles();
+    let width = dimension.x / 2.0;
+    let length = dimension.y / 2.0;
+    let height = dimension.z / 2.0;
+
+    let pw = offset.x + width;
+    let mw = offset.x - width;
+    let pl = offset.y + length;
+    let ml = offset.y - length;
+
+    let mut pointss: Vec<Vec<Point3<f64>>> = Vec::new();
+
+    if angles.0.abs() < 0.0001 && angles.1.abs() < 0.0001 {
+        // cube about parallel to floor, only draw the top
+        let points = vec![
+            iso.transform_point(&Point3::new(pw, pl, 0.0)),
+            iso.transform_point(&Point3::new(pw, ml, 0.0)),
+            iso.transform_point(&Point3::new(mw, ml, 0.0)),
+            iso.transform_point(&Point3::new(mw, pl, 0.0)),
+            iso.transform_point(&Point3::new(pw, pl, 0.0)),
+        ];
+        pointss.push(points)
+    } else {
+        // Other faces may be visible, render all of them
+        let ph = offset.z + height;
+        let mh = offset.z - height;
+        let face_top = vec![
+            iso.transform_point(&Point3::new(pw, pl, ph)),
+            iso.transform_point(&Point3::new(pw, ml, ph)),
+            iso.transform_point(&Point3::new(mw, ml, ph)),
+            iso.transform_point(&Point3::new(mw, pl, ph)),
+            iso.transform_point(&Point3::new(mw, pl, ph)),
+        ];
+        let face_bottom = vec![
+            iso.transform_point(&Point3::new(pw, pl, mh)),
+            iso.transform_point(&Point3::new(pw, ml, mh)),
+            iso.transform_point(&Point3::new(mw, ml, mh)),
+            iso.transform_point(&Point3::new(mw, pl, mh)),
+            iso.transform_point(&Point3::new(mw, pl, mh)),
+        ];
+        let a = vec![
+            iso.transform_point(&Point3::new(pw, pl, ph)),
+            iso.transform_point(&Point3::new(pw, pl, mh)),
+        ];
+        let b = vec![
+            iso.transform_point(&Point3::new(mw, pl, ph)),
+            iso.transform_point(&Point3::new(mw, pl, mh)),
+        ];
+        let c = vec![
+            iso.transform_point(&Point3::new(pw, ml, ph)),
+            iso.transform_point(&Point3::new(pw, ml, mh)),
+        ];
+        let d = vec![
+            iso.transform_point(&Point3::new(mw, ml, ph)),
+            iso.transform_point(&Point3::new(mw, ml, mh)),
+        ];
+        pointss.extend([face_top, face_bottom, a, b, c, d]);
+    }
+
+    return from_point_strips(&pointss, color);
+}
+
+fn parse_arrow_msg(
     msg: &rosrust_msg::visualization_msgs::Marker,
-    tf: &rosrust_msg::geometry_msgs::Transform,
+    color: &tui::style::Color,
+    iso: &Isometry3<f64>,
+) -> Vec<Line> {
+    let lines = match msg.points.len() {
+        0 => {
+            let mut lines: Vec<Line> = Vec::new();
+            // method 1: Position/Orientation -> scale is the arrow dimension
+            let p1 = iso.transform_point(&Point3::new(0.0, 0.0, 0.0));
+            let p2 = iso.transform_point(&Point3::new(msg.scale.x, 0.0, 0.0));
+            lines.push(Line {
+                x1: p1.x,
+                y1: p1.y,
+                x2: p2.x,
+                y2: p2.y,
+                color: *color,
+            });
+            let angle = PI / 4.0;
+            let r = msg.scale.y / 2.0 / angle.cos();
+            let a = PI - angle;
+            lines.push(Line {
+                x1: p2.x,
+                y1: p2.y,
+                x2: p2.x + r * a.cos(),
+                y2: p2.y + r * a.sin(),
+                color: *color,
+            });
+            lines.push(Line {
+                x1: p2.x,
+                y1: p2.y,
+                x2: p2.x - r * a.cos(),
+                y2: p2.y - r * a.sin(),
+                color: *color,
+            });
+            lines
+        }
+        2 => {
+            // method 2: Start/End Pose -> 2 points controling the size
+            // scale x is arrow width (not used), y head width, z head length
+            let start = &msg.points[0];
+            let end = &msg.points[1];
+
+            let p1 = iso.transform_point(&Point3::new(start.x, start.y, start.z));
+            let p2 = iso.transform_point(&Point3::new(end.x, end.y, end.z));
+
+            let mut lines: Vec<Line> = Vec::new();
+            lines.push(Line {
+                x1: p1.x,
+                y1: p1.y,
+                x2: p2.x,
+                y2: p2.y,
+                color: *color,
+            });
+
+            let shaft_angle = (p2.y - p1.y).atan2(p2.x - p1.x);
+            let angle = msg.scale.y.atan2(2.0 * msg.scale.x);
+            let r = (msg.scale.x.powi(2) + msg.scale.y.powi(2)).sqrt();
+            let a = shaft_angle + PI - angle;
+            let b = shaft_angle + PI + angle;
+            lines.push(Line {
+                x1: p2.x,
+                y1: p2.y,
+                x2: p2.x + r * a.cos(),
+                y2: p2.y + r * a.sin(),
+                color: *color,
+            });
+            lines.push(Line {
+                x1: p2.x,
+                y1: p2.y,
+                x2: p2.x + r * b.cos(),
+                y2: p2.y + r * b.sin(),
+                color: *color,
+            });
+
+            lines
+        }
+        _ => Vec::new(),
+    };
+
+    lines
+}
+
+fn parse_cube_msg(
+    msg: &rosrust_msg::visualization_msgs::Marker,
+    color: &tui::style::Color,
+    iso: &Isometry3<f64>,
+) -> Vec<Line> {
+    return parse_cube(
+        &msg.scale,
+        &rosrust_msg::geometry_msgs::Point {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        },
+        color,
+        iso,
+    );
+}
+
+fn parse_cube_list_msg(
+    msg: &rosrust_msg::visualization_msgs::Marker,
+    color: &tui::style::Color,
+    iso: &Isometry3<f64>,
+) -> Vec<Line> {
+    let mut lines = Vec::new();
+
+    for point in msg.points.iter() {
+        lines.extend(parse_cube(&msg.scale, &point, color, iso));
+    }
+
+    lines
+}
+
+fn parse_line_strip_msg(
+    msg: &rosrust_msg::visualization_msgs::Marker,
+    color: &tui::style::Color,
+    iso: &Isometry3<f64>,
+) -> Vec<Line> {
+    let mut points: Vec<Point3<f64>> = Vec::new();
+
+    for point in msg.points.iter() {
+        points.push(iso.transform_point(&Point3::new(point.x, point.y, point.z)));
+    }
+
+    return from_point_strips(&vec![points], color);
+}
+
+fn parse_line_list_msg(
+    msg: &rosrust_msg::visualization_msgs::Marker,
+    color: &tui::style::Color,
+    iso: &Isometry3<f64>,
 ) -> Vec<Line> {
     let mut lines: Vec<Line> = Vec::new();
-    // get corner points of box
+
+    let mut point_it = msg.points.iter();
+
+    while let Some(msg_p1) = point_it.next() {
+        let p1 = iso.transform_point(&Point3::new(msg_p1.x, msg_p1.y, msg_p1.z));
+        let msg_p2 = point_it.next().expect("Malformed message.");
+        let p2 = iso.transform_point(&Point3::new(msg_p2.x, msg_p2.y, msg_p2.z));
+
+        lines.push(Line {
+            x1: p1.x,
+            y1: p1.y,
+            x2: p2.x,
+            y2: p2.y,
+            color: *color,
+        });
+    }
+    lines
+}
+
+fn parse_marker_msg(
+    msg: &rosrust_msg::visualization_msgs::Marker,
+    tf: &rosrust_msg::geometry_msgs::Transform,
+) -> TermvizMarker {
     let trans_marker_to_static_frame = isometry_from_transform(tf);
     let trans_to_marker = isometry_from_pose(&msg.pose);
 
@@ -25,153 +285,214 @@ pub fn marker_2_rectancle(
         (msg.color.b * 255.0) as u8,
     );
 
-    let p1 = iso.transform_point(&Point3::new(msg.scale.x / 2., msg.scale.y / 2., 0.0));
-    let p2 = iso.transform_point(&Point3::new(msg.scale.x / 2., -msg.scale.y / 2., 0.0));
-    let p3 = iso.transform_point(&Point3::new(-msg.scale.x / 2., -msg.scale.y / 2., 0.0));
-    let p4 = iso.transform_point(&Point3::new(-msg.scale.x / 2., msg.scale.y / 2., 0.0));
-    lines.push(Line {
-        x1: p1.x,
-        y1: p1.y,
-        x2: p2.x,
-        y2: p2.y,
-        color: color,
-    });
-    lines.push(Line {
-        x1: p2.x,
-        y1: p2.y,
-        x2: p3.x,
-        y2: p3.y,
-        color: color,
-    });
-    lines.push(Line {
-        x1: p3.x,
-        y1: p3.y,
-        x2: p4.x,
-        y2: p4.y,
-        color: color,
-    });
-    lines.push(Line {
-        x1: p4.x,
-        y1: p4.y,
-        x2: p1.x,
-        y2: p1.y,
-        color: color,
-    });
-    lines
+    let res = match msg.type_ as u8 {
+        rosrust_msg::visualization_msgs::Marker::ARROW => parse_arrow_msg(msg, &color, &iso),
+        rosrust_msg::visualization_msgs::Marker::CUBE => parse_cube_msg(msg, &color, &iso),
+        rosrust_msg::visualization_msgs::Marker::CUBE_LIST => {
+            parse_cube_list_msg(msg, &color, &iso)
+        }
+        rosrust_msg::visualization_msgs::Marker::LINE_STRIP => {
+            parse_line_strip_msg(msg, &color, &iso)
+        }
+        rosrust_msg::visualization_msgs::Marker::LINE_LIST => {
+            parse_line_list_msg(msg, &color, &iso)
+        }
+        _ => Vec::new(),
+    };
+
+    TermvizMarker {
+        lines: res,
+        id: msg.id,
+        ns: msg.ns.clone(),
+    }
 }
 
-pub struct MarkerListener {
-    pub config: ListenerConfig,
-    pub lines: Arc<RwLock<Vec<Line>>>,
+struct TermvizMarkerContainer {
+    _markers: BTreeMap<String, BTreeMap<i32, TermvizMarker>>,
+    _static_frame: String,
     _tf_listener: Arc<rustros_tf::TfListener>,
-    _subscriber: rosrust::Subscriber,
 }
 
-impl MarkerListener {
+impl TermvizMarkerContainer {
     pub fn new(
-        config: ListenerConfig,
         tf_listener: Arc<rustros_tf::TfListener>,
         static_frame: String,
-    ) -> MarkerListener {
-        let blines = Arc::new(RwLock::new(Vec::<Line>::new()));
-        let loop_lines = blines.clone();
-        let local_listener = tf_listener.clone();
+    ) -> TermvizMarkerContainer {
+        Self {
+            _markers: BTreeMap::<String, BTreeMap<i32, TermvizMarker>>::new(),
+            _static_frame: static_frame,
+            _tf_listener: tf_listener,
+        }
+    }
 
-        let _sub = rosrust::subscribe(
+    fn add_marker(&mut self, marker: &rosrust_msg::visualization_msgs::Marker) {
+        let transform = &self._tf_listener.clone().lookup_transform(
+            &marker.header.frame_id,
+            &self._static_frame.clone(),
+            marker.header.stamp,
+        );
+        match &transform {
+            Ok(transform) => transform,
+            Err(_e) => return,
+        };
+
+        self._markers
+            .entry(marker.ns.clone())
+            .and_modify(|namespace| {
+                let res = parse_marker_msg(&marker, &transform.as_ref().unwrap().transform);
+                namespace.insert(res.id, res);
+                if marker.ns.contains("edge") {
+                } else if marker.ns.contains("vert") {
+                } else {
+                    println!("Adding {} to namespace {}", marker.id, marker.ns);
+                }
+            })
+            .or_insert_with(|| {
+                let res = parse_marker_msg(&marker, &transform.as_ref().unwrap().transform);
+                let mut namespace = BTreeMap::<i32, TermvizMarker>::new();
+                namespace.insert(res.id, res);
+                println!("{} on new namespace {}", marker.id, marker.ns);
+                namespace
+            });
+    }
+
+    fn delete_marker(&mut self, marker_ns: String, marker_id: i32) {
+        self._markers.entry(marker_ns).and_modify(|namespace| {
+            namespace.remove(&marker_id);
+            println!("DELETE {}", marker_id);
+        });
+    }
+
+    fn clear(&mut self) {
+        self._markers.clear();
+    }
+
+    fn get_lines(&self) -> Vec<Line> {
+        let mut res = Vec::<Line>::new();
+        for namespace in self._markers.values() {
+            for marker in namespace.values() {
+                res.extend(marker.lines.to_vec());
+            }
+        }
+        res
+    }
+}
+
+pub struct MarkersListener {
+    _markers_container: Arc<RwLock<TermvizMarkerContainer>>,
+    _subscribers: Vec<Arc<Mutex<rosrust::Subscriber>>>,
+    _timer: Arc<Mutex<timer::Timer>>,
+}
+
+impl MarkersListener {
+    pub fn new(tf_listener: Arc<rustros_tf::TfListener>, static_frame: String) -> MarkersListener {
+        Self {
+            _markers_container: Arc::new(RwLock::new(TermvizMarkerContainer::new(
+                tf_listener,
+                static_frame,
+            ))),
+            _subscribers: Vec::new(),
+            _timer: Arc::new(Mutex::new(timer::Timer::new())),
+        }
+    }
+
+    /// Gets all the lines currently active, to render.
+    pub fn get_lines(&self) -> Vec<Line> {
+        let markers_container_ref = self._markers_container.read().unwrap();
+        markers_container_ref.get_lines()
+    }
+
+    /// Adds a subscriber for a marker topic.
+    ///
+    /// Arguments:
+    /// - `config`: Configuration containing the topic name.
+    pub fn add_marker_listener(&mut self, config: &ListenerConfig) {
+        let markers_container_ref = self._markers_container.clone();
+        let s_timer = self._timer.clone();
+
+        let sub = rosrust::subscribe(
             &config.topic,
             2,
             move |msg: rosrust_msg::visualization_msgs::Marker| {
-                let mut _lines = loop_lines.write().unwrap();
-                _lines.clear();
-                if msg.action != 0 {
+                let mut markers_container = markers_container_ref.write().unwrap();
+                let timer = s_timer.lock().unwrap();
+
+                match msg.action as u8 {
+                    rosrust_msg::visualization_msgs::Marker::ADD => {
+                        markers_container.add_marker(&msg)
+                    }
+                    rosrust_msg::visualization_msgs::Marker::DELETE => {
+                        markers_container.delete_marker(msg.ns.clone(), msg.id)
+                    }
+                    rosrust_msg::visualization_msgs::Marker::DELETEALL => markers_container.clear(),
+                    _ => return,
+                }
+
+                // Handle marker lifecycle
+                if msg.lifetime.seconds() == 0.0 {
                     return;
                 }
-                let res = &local_listener.clone().lookup_transform(
-                    &msg.header.frame_id,
-                    &static_frame.clone(),
-                    msg.header.stamp,
-                );
-                match &res {
-                    Ok(res) => res,
-                    Err(_e) => return,
-                };
 
-                _lines.extend(marker_2_rectancle(
-                    &msg,
-                    &res.as_ref().unwrap().transform,
-                ));
+                let marker_container_ref2 = markers_container_ref.clone();
+                let chrono_delay = chrono::Duration::seconds(msg.lifetime.sec as i64)
+                    + chrono::Duration::nanoseconds(msg.lifetime.nsec as i64);
+
+                timer.schedule_with_delay(chrono_delay, move || {
+                    let mut mc = marker_container_ref2.write().unwrap();
+                    mc.delete_marker(msg.ns.clone(), msg.id)
+                });
             },
-        )
-        .unwrap();
+        );
 
-        MarkerListener {
-            config,
-            lines: blines,
-            _tf_listener: tf_listener,
-            _subscriber: _sub,
-        }
+        self._subscribers.push(Arc::new(Mutex::new(sub.unwrap())));
     }
 
-    pub fn get_lines(&self) -> Vec<Line> {
-        self.lines.read().unwrap().to_vec()
-    }
-}
+    /// Adds a subscriber for a marker array message topic.
+    ///
+    /// # Arguments
+    /// * `config` - Configuration containing the topic.
+    pub fn add_marker_array_listener(&mut self, config: &ListenerConfig) {
+        let markers_container_ref = self._markers_container.clone();
+        let s_timer = self._timer.clone();
 
-pub struct MarkerArrayListener {
-    pub config: ListenerConfig,
-    pub lines: Arc<RwLock<Vec<Line>>>,
-    _tf_listener: Arc<rustros_tf::TfListener>,
-    _subscriber: rosrust::Subscriber,
-}
-
-impl MarkerArrayListener {
-    pub fn new(
-        config: ListenerConfig,
-        tf_listener: Arc<rustros_tf::TfListener>,
-        static_frame: String,
-    ) -> MarkerArrayListener {
-        let blines = Arc::new(RwLock::new(Vec::<Line>::new()));
-        let loop_lines = blines.clone();
-        let local_listener = tf_listener.clone();
-
-        let _sub = rosrust::subscribe(
+        let sub = rosrust::subscribe(
             &config.topic,
             2,
             move |msg: rosrust_msg::visualization_msgs::MarkerArray| {
-                let mut _lines = loop_lines.write().unwrap();
-                _lines.clear();
+                let mut markers_container = markers_container_ref.write().unwrap();
+                let timer = s_timer.lock().unwrap();
+
                 for marker in msg.markers {
-                    if marker.action != 0 {
+                    match marker.action as u8 {
+                        rosrust_msg::visualization_msgs::Marker::ADD => {
+                            markers_container.add_marker(&marker)
+                        }
+                        rosrust_msg::visualization_msgs::Marker::DELETE => {
+                            markers_container.delete_marker(marker.ns.clone(), marker.id)
+                        }
+                        rosrust_msg::visualization_msgs::Marker::DELETEALL => {
+                            markers_container.clear()
+                        }
+                        _ => continue,
+                    }
+
+                    // Handle marker lifecycle
+                    if marker.lifetime.seconds() == 0.0 {
                         continue;
                     }
-                    let res = &local_listener.clone().lookup_transform(
-                        &marker.header.frame_id,
-                        &static_frame.clone(),
-                        marker.header.stamp,
-                    );
-                    match &res {
-                        Ok(res) => res,
-                        Err(_e) => continue,
-                    };
 
-                    _lines.extend(marker_2_rectancle(
-                        &marker,
-                        &res.as_ref().unwrap().transform,
-                    ));
+                    let marker_container_ref2 = markers_container_ref.clone();
+                    let chrono_delay = chrono::Duration::seconds(marker.lifetime.sec as i64)
+                        + chrono::Duration::nanoseconds(marker.lifetime.nsec as i64);
+
+                    timer.schedule_with_delay(chrono_delay, move || {
+                        let mut mc = marker_container_ref2.write().unwrap();
+                        mc.delete_marker(marker.ns.clone(), marker.id)
+                    });
                 }
             },
-        )
-        .unwrap();
+        );
 
-        MarkerArrayListener {
-            config,
-            lines: blines,
-            _tf_listener: tf_listener,
-            _subscriber: _sub,
-        }
-    }
-
-    pub fn get_lines(&self) -> Vec<Line> {
-        self.lines.read().unwrap().to_vec()
+        self._subscribers.push(Arc::new(Mutex::new(sub.unwrap())));
     }
 }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -2,11 +2,11 @@
 //!
 //! ROS has a type of message dedicated to visualization: visualization_msgs::Marker.
 //! This module allows to subsribe to topics that publish them and project them into the
-//! 2D offset.y + dimension.y / 2.0ane. Finally, it takes care of their lifecycle: ADD, DELETE and timeout.
+//! 2D plane. Finally, it takes care of their lifecycle: ADD, DELETE and timeout.
 use crate::config::ListenerConfig;
 use nalgebra::base::Vector3;
 use nalgebra::geometry::Isometry3;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::f64::consts::PI;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -22,8 +22,8 @@ struct TermvizMarker {
     pub id: i32,
 }
 
-///Creates a list of lines from N line stips.
-/// Arguments:
+/// Creates a list of lines from N line strips.
+/// # Arguments
 /// - `strips`: A vector of vector of points. Each element is a strip, i.e. a single
 ///             broken line. Each strip has N points that form N-1 lines.
 fn from_point_strips(strips: &Vec<Vec<Point3<f64>>>, color: &Color) -> Vec<Line> {
@@ -49,11 +49,11 @@ fn from_point_strips(strips: &Vec<Vec<Point3<f64>>>, color: &Color) -> Vec<Line>
     lines
 }
 
-///Creates the visible lines for a cube.
+/// Creates the visible lines for a cube.
 ///
-/// If the cube is parallel to the z-offset.y + dimension.y / 2.0an, the visible lines are simoffset.y + dimension.y / 2.0y the 4 top ones.
+/// If the cube is parallel to the plan, the visible lines are simoffset.y + dimension.y / 2.0y the 4 top ones.
 /// Else, we draw all 12 edges.
-/// Arguments:
+/// # Arguments:
 /// - `dimension`: size of the cube as width, length, height.
 /// - `offset`: Offset of the center of the cube in the iso transformation.
 /// - `color`: Color of the cube.
@@ -66,7 +66,7 @@ fn parse_cube(
 ) -> Vec<Line> {
     let angles = iso.rotation.euler_angles();
 
-    let mut pointss: Vec<Vec<Point3<f64>>> = Vec::new();
+    let mut points_strips: Vec<Vec<Point3<f64>>> = Vec::new();
 
     let face_top = vec![
         iso.transform_point(&Point3::new(
@@ -95,7 +95,7 @@ fn parse_cube(
             offset.z + dimension.z / 2.0,
         )),
     ];
-    pointss.push(face_top);
+    points_strips.push(face_top);
 
     if angles.0.abs() > 0.0001 || angles.1.abs() > 0.0001 {
         // Other faces may be visible, render all of them
@@ -174,10 +174,10 @@ fn parse_cube(
                 offset.z - dimension.z / 2.0,
             )),
         ];
-        pointss.extend([face_bottom, a, b, c, d]);
+        points_strips.extend([face_bottom, a, b, c, d]);
     }
 
-    return from_point_strips(&pointss, color);
+    return from_point_strips(&points_strips, color);
 }
 
 fn parse_arrow_msg(
@@ -385,16 +385,16 @@ fn parse_marker_msg(
     }
 }
 
-///Class that holds all the markers currently active.
+/// Class that holds all the markers currently active.
 ///
 /// The markers are ordered in a double dictionary, which allows to manage namespaces.
 /// Each namespace has its own set of IDs. This structure allows to have markers with
 /// same IDs on different namespaces. Note that this class should be shared by all
 /// publishers such that they can be managed globally.
 struct TermvizMarkerContainer {
-    _markers: BTreeMap<String, BTreeMap<i32, TermvizMarker>>,
-    _static_frame: String,
-    _tf_listener: Arc<rustros_tf::TfListener>,
+    markers: HashMap<String, HashMap<i32, TermvizMarker>>,
+    static_frame: String,
+    tf_listener: Arc<rustros_tf::TfListener>,
 }
 
 impl TermvizMarkerContainer {
@@ -403,16 +403,16 @@ impl TermvizMarkerContainer {
         static_frame: String,
     ) -> TermvizMarkerContainer {
         Self {
-            _markers: BTreeMap::<String, BTreeMap<i32, TermvizMarker>>::new(),
-            _static_frame: static_frame,
-            _tf_listener: tf_listener,
+            markers: HashMap::<String, HashMap<i32, TermvizMarker>>::new(),
+            static_frame: static_frame,
+            tf_listener: tf_listener,
         }
     }
 
     fn add_marker(&mut self, marker: &rosrust_msg::visualization_msgs::Marker) {
-        let transform = &self._tf_listener.clone().lookup_transform(
+        let transform = &self.tf_listener.clone().lookup_transform(
             &marker.header.frame_id,
-            &self._static_frame.clone(),
+            &self.static_frame.clone(),
             marker.header.stamp,
         );
         match &transform {
@@ -420,7 +420,7 @@ impl TermvizMarkerContainer {
             Err(_e) => return,
         };
 
-        self._markers
+        self.markers
             .entry(marker.ns.clone())
             .and_modify(|namespace| {
                 let res = parse_marker_msg(&marker, &transform.as_ref().unwrap().transform);
@@ -428,25 +428,25 @@ impl TermvizMarkerContainer {
             })
             .or_insert_with(|| {
                 let res = parse_marker_msg(&marker, &transform.as_ref().unwrap().transform);
-                let mut namespace = BTreeMap::<i32, TermvizMarker>::new();
+                let mut namespace = HashMap::<i32, TermvizMarker>::new();
                 namespace.insert(res.id, res);
                 namespace
             });
     }
 
     fn delete_marker(&mut self, marker_ns: String, marker_id: i32) {
-        self._markers.entry(marker_ns).and_modify(|namespace| {
+        self.markers.entry(marker_ns).and_modify(|namespace| {
             namespace.remove(&marker_id);
         });
     }
 
     fn clear(&mut self) {
-        self._markers.clear();
+        self.markers.clear();
     }
 
     fn clear_namespace(&mut self, marker_ns: String) -> Vec<i32> {
         let mut res = Vec::new();
-        self._markers.entry(marker_ns).and_modify(|namespace| {
+        self.markers.entry(marker_ns).and_modify(|namespace| {
             for marker in namespace.values() {
                 res.push(marker.id);
             }
@@ -457,7 +457,7 @@ impl TermvizMarkerContainer {
 
     fn get_lines(&self) -> Vec<Line> {
         let mut res = Vec::<Line>::new();
-        for namespace in self._markers.values() {
+        for namespace in self.markers.values() {
             for marker in namespace.values() {
                 res.extend(marker.lines.to_vec());
             }
@@ -466,7 +466,7 @@ impl TermvizMarkerContainer {
     }
 }
 
-///Class that handles the lifecycle of the markers.
+/// Class that handles the lifecycle of the markers.
 ///
 /// Markers that provide a lifecycle (i.e. not 0) need to be deleted from the container
 /// once the lifecycle is reached. To do this we add another container which has a timer.
@@ -476,23 +476,24 @@ impl TermvizMarkerContainer {
 /// and a list. A repeated task is given to the timer to consume the list of deleted
 /// marker and free the guards.
 struct MarkersLifecycle {
-    _markers_container: Arc<RwLock<TermvizMarkerContainer>>,
-    _deleted_markers: Arc<Mutex<Vec<(String, i32)>>>,
-    _guards: Arc<Mutex<BTreeMap<(String, i32), timer::Guard>>>,
-    _timer: Arc<Mutex<timer::Timer>>,
-    _cleaner_guard: timer::Guard,
+    markers_container: Arc<RwLock<TermvizMarkerContainer>>,
+    deleted_markers: Arc<Mutex<Vec<(String, i32)>>>,
+    guards: Arc<Mutex<HashMap<(String, i32), timer::Guard>>>,
+    timer: Arc<Mutex<timer::Timer>>,
+    #[allow(dead_code)]  // because the guard is never used but must be kept
+    cleaner_guard: timer::Guard,
 }
 
 impl MarkersLifecycle {
     pub fn new(marker_container: TermvizMarkerContainer) -> MarkersLifecycle {
         let timer = Arc::new(Mutex::new(timer::Timer::new()));
         let deleted_markers = Arc::new(Mutex::new(Vec::<(String, i32)>::new()));
-        let guards = Arc::new(Mutex::new(BTreeMap::<(String, i32), timer::Guard>::new()));
+        let guards = Arc::new(Mutex::new(HashMap::<(String, i32), timer::Guard>::new()));
 
         let clean_job_delete_markers_ref = deleted_markers.clone();
         let clean_job_guards_ref = guards.clone();
 
-        let cleaner_guard =
+        let guard =
             timer
                 .lock()
                 .unwrap()
@@ -507,23 +508,23 @@ impl MarkersLifecycle {
                 });
 
         Self {
-            _markers_container: Arc::new(RwLock::new(marker_container)),
-            _deleted_markers: deleted_markers,
-            _guards: guards,
-            _timer: timer,
-            _cleaner_guard: cleaner_guard,
+            markers_container: Arc::new(RwLock::new(marker_container)),
+            deleted_markers: deleted_markers,
+            guards: guards,
+            timer: timer,
+            cleaner_guard: guard,
         }
     }
 
     fn add_marker(&mut self, marker: &rosrust_msg::visualization_msgs::Marker) {
-        self._markers_container.write().unwrap().add_marker(marker);
+        self.markers_container.write().unwrap().add_marker(marker);
 
         // Handle marker lifecycle
         if marker.lifetime.seconds() == 0.0 {
             return;
         }
 
-        let markers_container_ref = self._markers_container.clone();
+        let markers_container_ref = self.markers_container.clone();
 
         let chrono_delay = chrono::Duration::seconds(marker.lifetime.sec as i64)
             + chrono::Duration::nanoseconds(marker.lifetime.nsec as i64);
@@ -531,7 +532,7 @@ impl MarkersLifecycle {
         let marker_info = (marker.ns.clone(), marker.id);
 
         let guard_ = self
-            ._timer
+            .timer
             .lock()
             .unwrap()
             .schedule_with_delay(chrono_delay, move || {
@@ -539,16 +540,16 @@ impl MarkersLifecycle {
                 mc.delete_marker(marker_info.0.clone(), marker_info.1);
             });
 
-        let mut guards_ref = self._guards.lock().unwrap();
+        let mut guards_ref = self.guards.lock().unwrap();
         guards_ref.insert((marker.ns.clone(), marker.id), guard_);
     }
 
     fn delete_marker(&mut self, marker_ns: String, marker_id: i32) {
-        self._markers_container
+        self.markers_container
             .write()
             .unwrap()
             .delete_marker(marker_ns.clone(), marker_id);
-        self._deleted_markers
+        self.deleted_markers
             .lock()
             .unwrap()
             .push((marker_ns, marker_id));
@@ -556,57 +557,55 @@ impl MarkersLifecycle {
 
     fn clear(&mut self) {
         // loose the guards if any, to cancel the timer tasks
-        self._deleted_markers.lock().unwrap().clear();
-        self._guards.lock().unwrap().clear();
+        self.deleted_markers.lock().unwrap().clear();
+        self.guards.lock().unwrap().clear();
 
-        self._markers_container.write().unwrap().clear();
+        self.markers_container.write().unwrap().clear();
     }
 
     fn clear_namespace(&mut self, marker_ns: String) {
         let removed_ids = self
-            ._markers_container
+            .markers_container
             .write()
             .unwrap()
             .clear_namespace(marker_ns.clone());
 
         // schedule deletion of the cleared markers
-        let mut deleted_markers = self._deleted_markers.lock().unwrap();
-        for id in removed_ids {
-            deleted_markers.push((marker_ns.clone(), id));
-        }
+        let mut deleted_markers = self.deleted_markers.lock().unwrap();
+        deleted_markers.extend(removed_ids.iter().map(|&id| (marker_ns.clone(), id)));
     }
 
     fn get_lines(&self) -> Vec<Line> {
-        self._markers_container.write().unwrap().get_lines()
+        self.markers_container.write().unwrap().get_lines()
     }
 }
 
 pub struct MarkersListener {
-    _markers_lifecycle: Arc<RwLock<MarkersLifecycle>>,
-    _subscribers: Vec<Arc<Mutex<rosrust::Subscriber>>>,
+    markers_lifecycle: Arc<RwLock<MarkersLifecycle>>,
+    subscribers: Vec<Arc<Mutex<rosrust::Subscriber>>>,
 }
 
 impl MarkersListener {
     pub fn new(tf_listener: Arc<rustros_tf::TfListener>, static_frame: String) -> MarkersListener {
         let marker_container = TermvizMarkerContainer::new(tf_listener, static_frame);
         Self {
-            _markers_lifecycle: Arc::new(RwLock::new(MarkersLifecycle::new(marker_container))),
-            _subscribers: Vec::new(),
+            markers_lifecycle: Arc::new(RwLock::new(MarkersLifecycle::new(marker_container))),
+            subscribers: Vec::new(),
         }
     }
 
     /// Gets all the lines currently active, to render.
     pub fn get_lines(&self) -> Vec<Line> {
-        let markers_container_ref = self._markers_lifecycle.read().unwrap();
+        let markers_container_ref = self.markers_lifecycle.read().unwrap();
         markers_container_ref.get_lines()
     }
 
     /// Adds a subscriber for a marker topic.
     ///
-    /// Arguments:
+    /// # Arguments
     /// - `config`: Configuration containing the topic name.
     pub fn add_marker_listener(&mut self, config: &ListenerConfig) {
-        let markers_container_ref = self._markers_lifecycle.clone();
+        let markers_container_ref = self.markers_lifecycle.clone();
 
         let sub = rosrust::subscribe(
             &config.topic,
@@ -627,7 +626,7 @@ impl MarkersListener {
             },
         );
 
-        self._subscribers.push(Arc::new(Mutex::new(sub.unwrap())));
+        self.subscribers.push(Arc::new(Mutex::new(sub.unwrap())));
     }
 
     /// Adds a subscriber for a marker array message topic.
@@ -635,7 +634,7 @@ impl MarkersListener {
     /// # Arguments
     /// * `config` - Configuration containing the topic.
     pub fn add_marker_array_listener(&mut self, config: &ListenerConfig) {
-        let markers_container_ref = self._markers_lifecycle.clone();
+        let markers_container_ref = self.markers_lifecycle.clone();
 
         let sub = rosrust::subscribe(
             &config.topic,
@@ -660,6 +659,6 @@ impl MarkersListener {
             },
         );
 
-        self._subscribers.push(Arc::new(Mutex::new(sub.unwrap())));
+        self.subscribers.push(Arc::new(Mutex::new(sub.unwrap())));
     }
 }


### PR DESCRIPTION
Hello, 

I refactored the marker module to:
-  support new geometries (CUBE, CUBE_LIST, LINE_LIST, LINE_STRIP, ARROW)
- support ADD, DELETE and DELETEALL
- support lifecycle
In order to do this, I had to move from one class holding lines per topic to a central class holding marker. There are now 4 classes:
- TermvizMarker which holds the geometry and marker id
- MarkersContainer which holds all the active markers and manages the parsing from the visu msg to geometries
- MarkersLifecycle which manages the MarkersContainer to delete outdated markers using a timer
- MarkersListener which allows the clients to subscribe to different topics (and types) and retrieve all the active geometries. 

Note that such structure was needed because in the ros Subscriber and timer, one cannot use self but can use a clone of an Arc-protected instance. 

The MarkersLifecycle has a particularly complex system because it needs to keep the guard object issued by the timer, else the task is unscheduled. To do this I used two containers to hold reference of what was schedule and what needs to be cleaned. An extra timer task does the cleaning periodically. 