### PR TITLE
Allow image rotation

### DIFF
--- a/src/app_modes/image_view.rs
+++ b/src/app_modes/image_view.rs
@@ -1,6 +1,6 @@
 use self::image::ImageListener;
 use crate::app_modes::{input, AppMode, BaseMode, Drawable};
-use crate::config::ListenerConfig;
+use crate::config::ImageListenerConfig;
 use crate::image;
 use tui::backend::Backend;
 use tui::layout::{Alignment, Constraint, Layout};
@@ -15,7 +15,7 @@ pub struct ImageView {
 }
 
 impl ImageView {
-    pub fn new(image_topics: Vec<ListenerConfig>) -> ImageView {
+    pub fn new(image_topics: Vec<ImageListenerConfig>) -> ImageView {
         let mut images: Vec<image::ImageListener> = Vec::new();
         for image_config in image_topics {
             images.push(image::ImageListener::new(image_config));
@@ -57,6 +57,12 @@ impl AppMode for ImageView {
                     self.images[self.active_sub].deactivate();
                     self.active_sub = (self.active_sub + 1) % self.images.len();
                 }
+                input::ROTATE_RIGHT => {
+                    self.images[self.active_sub].rotate(90);
+                }
+                input::ROTATE_LEFT => {
+                    self.images[self.active_sub].rotate(-90);
+                }
                 _ => (),
             }
         }
@@ -75,6 +81,14 @@ impl AppMode for ImageView {
             [
                 input::RIGHT.to_string(),
                 "Switches to the next image.".to_string(),
+            ],
+            [
+                input::ROTATE_LEFT.to_string(),
+                "Rotates the image counter-clockwise.".to_string(),
+            ],
+            [
+                input::ROTATE_RIGHT.to_string(),
+                "Rotates the image clockwise.".to_string(),
             ],
         ]
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 
+fn default_int() -> i64 {
+    0
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Color {
     pub r: u8,
@@ -14,6 +18,13 @@ pub struct Color {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListenerConfig {
     pub topic: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImageListenerConfig {
+    pub topic: String,
+    #[serde(default = "default_int")]
+    pub rotation: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -46,7 +57,7 @@ pub struct TermvizConfig {
     pub map_topics: Vec<ListenerConfigColor>,
     pub laser_topics: Vec<ListenerConfigColor>,
     pub marker_topics: Vec<ListenerConfig>,
-    pub image_topics: Vec<ListenerConfig>,
+    pub image_topics: Vec<ImageListenerConfig>,
     pub marker_array_topics: Vec<ListenerConfig>,
     pub send_pose_topic: String,
     pub target_framerate: i64,
@@ -80,8 +91,9 @@ impl Default for TermvizConfig {
             marker_topics: vec![ListenerConfig {
                 topic: "marker".to_string(),
             }],
-            image_topics: vec![ListenerConfig {
+            image_topics: vec![ImageListenerConfig {
                 topic: "image_rect".to_string(),
+                rotation: 0,
             }],
             send_pose_topic: "initialpose".to_string(),
             target_framerate: 30,


### PR DESCRIPTION
I just implemented 180 degree rotation out of popular demand.  Do you think 180 is enough for now? image.rs would allow 90 deg steps by default. Imageproc can do free rotations  https://docs.rs/imageproc/0.6.0/imageproc/affine/fn.rotate.html

