### PR TITLE
Visualize Marker::POINTS

### DIFF
--- a/src/marker.rs
+++ b/src/marker.rs
@@ -310,6 +310,14 @@ fn parse_cube_list_msg(
     lines
 }
 
+fn parse_points_msg(
+  msg: &rosrust_msg::visualization_msgs::Marker,
+  color: &tui::style::Color,
+  iso: &Isometry3<f64>,
+) -> Vec<Line> {
+  return parse_cube_list_msg(msg,color,iso);
+}
+
 fn parse_line_strip_msg(
     msg: &rosrust_msg::visualization_msgs::Marker,
     color: &tui::style::Color,
@@ -369,6 +377,9 @@ fn parse_marker_msg(
         rosrust_msg::visualization_msgs::Marker::CUBE => parse_cube_msg(msg, &color, &iso),
         rosrust_msg::visualization_msgs::Marker::CUBE_LIST => {
             parse_cube_list_msg(msg, &color, &iso)
+        }
+        rosrust_msg::visualization_msgs::Marker::POINTS => {
+          parse_points_msg(msg, &color, &iso)
         }
         rosrust_msg::visualization_msgs::Marker::LINE_STRIP => {
             parse_line_strip_msg(msg, &color, &iso)


### PR DESCRIPTION
Marker Points are not visualized at the moment.

An easier approach is to consider them like a cube list.
Since the z scale is not used for points (https://wiki.ros.org/rviz/DisplayTypes/Marker#Points_.28POINTS.3D8.29), we can also discuss if it could make sense to set it to 0, or we just keep what the user send like in the implementation below.
 
 In rviz the orientatoin of points depends on the orientation of the camera but I think that is not fundamental.  
