### PR TITLE
Use clap for CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["assets/*", ".github"]
 approx = "0.5.1"
 byteorder = "*"
 chrono = "0.2.25"
+clap = "*"
 image = "*"
 colorgrad = "*"
 nalgebra = ">=0.29.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,12 +209,12 @@ pub fn ask_store() -> bool {
     }
 }
 
-pub fn get_config(args: Vec<String>) -> Result<TermvizConfig, confy::ConfyError> {
+pub fn get_config(config_path: Option<&String>) -> Result<TermvizConfig, confy::ConfyError> {
     let mut cfg = TermvizConfig::default();
     let user_path = confy::get_configuration_file_path("termviz", "termviz")?;
-    if args.len() > 1 {
+    if config_path.is_some() {
         // config path provided by command line arg
-        cfg = confy::load_path(&args[1]).unwrap();
+        cfg = confy::load_path(config_path.unwrap()).unwrap();
     } else if Path::new(&user_path).exists() {
         // use user config if exists
         cfg = confy::load("termviz", "termviz")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,18 +15,25 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use clap::{Arg, Command};
 use event::{Config, Event, Events};
 use rosrust;
 use rustros_tf;
-use std::env;
 use std::error::Error;
 use termion::event::Key;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Terminal initialization
 
-    let args: Vec<String> = env::args().collect();
-    let conf = config::get_config(args).unwrap();
+    let matches = Command::new("termviz")
+        .about("ROS visualization on the terminal")
+        .arg(
+            Arg::new("config").long_help("Optional YAML file with a custom termviz configuration."),
+        )
+        .after_help("More documentation can be found at: https://github.com/carzum/termviz")
+        .get_matches();
+
+    let conf = config::get_config(matches.get_one("config")).unwrap();
     println!("Connecting to ros...");
     rosrust::init("termviz");
 


### PR DESCRIPTION
Simple change to get a nicely formatted --help for free and to allow more arguments in the future.