### PR TITLE
Multicolored line lists

### DIFF
--- a/src/marker.rs
+++ b/src/marker.rs
@@ -340,8 +340,20 @@ fn parse_line_list_msg(
     let mut lines: Vec<Line> = Vec::new();
 
     let mut point_it = msg.points.iter();
+    let mut color_it = msg.colors.iter();
 
     while let Some(msg_p1) = point_it.next() {
+        let msg_color = color_it.next();
+        let local_color_1 = match msg_color {
+            Some(x) => Color::Rgb(
+                (x.r * 255.0) as u8,
+                (x.g * 255.0) as u8,
+                (x.b * 255.0) as u8,
+                ),
+            None => *color,
+        };
+        color_it.next();// these come in pairs, but I currently don't see the necessity to implement gradients
+
         let p1 = iso.transform_point(&Point3::new(msg_p1.x, msg_p1.y, msg_p1.z));
         let msg_p2 = point_it.next().expect("Malformed message.");
         let p2 = iso.transform_point(&Point3::new(msg_p2.x, msg_p2.y, msg_p2.z));
@@ -351,7 +363,7 @@ fn parse_line_list_msg(
             y1: p1.y,
             x2: p2.x,
             y2: p2.y,
-            color: *color,
+            color: local_color_1,
         });
     }
     lines

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -311,11 +311,11 @@ fn parse_cube_list_msg(
 }
 
 fn parse_points_msg(
-  msg: &rosrust_msg::visualization_msgs::Marker,
-  color: &tui::style::Color,
-  iso: &Isometry3<f64>,
+    msg: &rosrust_msg::visualization_msgs::Marker,
+    color: &tui::style::Color,
+    iso: &Isometry3<f64>,
 ) -> Vec<Line> {
-  return parse_cube_list_msg(msg,color,iso);
+    return parse_cube_list_msg(msg, color, iso);
 }
 
 fn parse_line_strip_msg(
@@ -349,10 +349,10 @@ fn parse_line_list_msg(
                 (x.r * 255.0) as u8,
                 (x.g * 255.0) as u8,
                 (x.b * 255.0) as u8,
-                ),
+            ),
             None => *color,
         };
-        color_it.next();// these come in pairs, but I currently don't see the necessity to implement gradients
+        color_it.next(); // these come in pairs, but I currently don't see the necessity to implement gradients
 
         let p1 = iso.transform_point(&Point3::new(msg_p1.x, msg_p1.y, msg_p1.z));
         let msg_p2 = point_it.next().expect("Malformed message.");
@@ -390,9 +390,7 @@ fn parse_marker_msg(
         rosrust_msg::visualization_msgs::Marker::CUBE_LIST => {
             parse_cube_list_msg(msg, &color, &iso)
         }
-        rosrust_msg::visualization_msgs::Marker::POINTS => {
-          parse_points_msg(msg, &color, &iso)
-        }
+        rosrust_msg::visualization_msgs::Marker::POINTS => parse_points_msg(msg, &color, &iso),
         rosrust_msg::visualization_msgs::Marker::LINE_STRIP => {
             parse_line_strip_msg(msg, &color, &iso)
         }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -344,7 +344,7 @@ fn parse_line_list_msg(
 
     while let Some(msg_p1) = point_it.next() {
         let msg_color = color_it.next();
-        let local_color_1 = match msg_color {
+        let local_color = match msg_color {
             Some(x) => Color::Rgb(
                 (x.r * 255.0) as u8,
                 (x.g * 255.0) as u8,
@@ -363,7 +363,7 @@ fn parse_line_list_msg(
             y1: p1.y,
             x2: p2.x,
             y2: p2.y,
-            color: local_color_1,
+            color: local_color,
         });
     }
     lines


### PR DESCRIPTION
The previous implementation only used the header color for a LINE_LIST visualization.
This marker type, however, uses a pair of colors for each line segment in the list.
In our use-cases, we often had multi-colored LINE_LISTs, wherein we did not even fill in the header color, meaning that the marker was not displayed at all.
I have modified the visualization to draw each segment with the first of the two colors associated with it.
![image](https://user-images.githubusercontent.com/21334530/214118135-bf5f5bd6-a902-4a2c-b014-7a860f135124.png)
