### PR TITLE
Support for multiple topics and types in Send Pose

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Pressing `h` shows the help screen, which will describe the current mode and the
 
 ### Send pose mode
 
-The mode allows to publish a `geometry_msgs::PoseWithCovarianceStamped` message on a topic. The desired pose can be selected by moving the outline of the robot in the map. Confirming the operation (`Enter` by default) publishes the pose on the topic specified under `send_pose_topic` in the configuration file.
+The mode allows to publish a pose message on a topic, for example to send an initial pose estimate to a localization system or a goal pose for the navigation stack. The supported types are `geometry_msgs::Pose`, `geometry_msgs::PoseStamped`, and `geometry_msgs::PoseWithCovarianceStamped`. The desired pose can be selected by moving the outline of the robot in the map. Confirming the operation (`Enter` by default) publishes the pose on the selected topic among those specified under `send_pose_topics` in the configuration file. The target topic can be selected using the "next" and "previous" keys (`n` and `b` by default).
 
 ### Teleoperate mode
 
@@ -116,7 +116,9 @@ pose_stamped_topics:            # geometry_msgs::PoseStamped topics.
       g: 0
       b: 0
     length: 0.2                 # Length of the axes.
-send_pose_topic: initialpose    # Topic on which to publish poses in Send Pose mode.
+send_pose_topics:               # Topics on which to publish poses in Send Pose mode.
+  - topic: pose                 # The topic name.
+    msg_type: PoseStamped       # The topic's type. Supported are Pose, PoseStamped and PoseWithCovarianceStamped.
 target_framerate: 30            # Refresh rate of the visualization. Lower this if the ssh connection is slow.
 axis_length: 0.5                # Length of the axes of the robot frame
 visible_area:                   # Default boundaries of the visible areas. Determines the initial level of zoom.

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,7 +55,7 @@ impl<B: Backend> App<B> {
             size().unwrap(),
         )));
         let send_pose = Box::new(app_modes::send_pose::SendPose::new(
-            &config.send_pose_topic,
+            &config.send_pose_topics,
             viewport.clone(),
         ));
         let teleop = Box::new(app_modes::teleoperate::Teleoperate::new(
@@ -144,7 +144,7 @@ impl<B: Backend> App<B> {
             .map(|(i, mode)| {
                 [
                     format!("Switch to mode {}", (i + 1)),
-                    "Switch to ".to_string() + &mode.get_name() + &" mode.".to_string(),
+                    "Switches to ".to_string() + &mode.get_name() + &" mode.".to_string(),
                 ]
             })
             .collect();

--- a/src/app_modes/image_view.rs
+++ b/src/app_modes/image_view.rs
@@ -48,7 +48,7 @@ impl AppMode for ImageView {
     fn handle_input(&mut self, input: &String) {
         if self.images.len() > 0 {
             match input.as_str() {
-                input::LEFT => {
+                input::LEFT | input::PREVIOUS => {
                     self.images[self.active_sub].deactivate();
                     self.active_sub = if self.active_sub > 0 {
                         self.active_sub - 1
@@ -56,7 +56,7 @@ impl AppMode for ImageView {
                         self.images.len() - 1
                     };
                 }
-                input::RIGHT => {
+                input::RIGHT | input::NEXT => {
                     self.images[self.active_sub].deactivate();
                     self.active_sub = (self.active_sub + 1) % self.images.len();
                 }

--- a/src/app_modes/mod.rs
+++ b/src/app_modes/mod.rs
@@ -33,6 +33,8 @@ pub mod input {
     pub const ZOOM_OUT: &str = "Zoom out";
     pub const INCREMENT_STEP: &str = "Increment step";
     pub const DECREMENT_STEP: &str = "Decrement step";
+    pub const NEXT: &str = "Next";
+    pub const PREVIOUS: &str = "Previous";
     pub const SHOW_HELP: &str = "Show help";
     pub const UNMAPPED: &str = "Any other";
 }

--- a/src/app_modes/teleoperate.rs
+++ b/src/app_modes/teleoperate.rs
@@ -80,7 +80,7 @@ impl AppMode for Teleoperate {
         // If the velocity is reset to 0 only publish it once
         // this prevents the robot from being blocked if the
         // app mode is not closed
-        if  !self.publish_cmd_vel_when_idle
+        if !self.publish_cmd_vel_when_idle
             && self.current_velocities.x == 0 as f64
             && self.current_velocities.y == 0 as f64
             && self.current_velocities.theta == 0 as f64

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,12 @@ pub struct ImageListenerConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SendPoseConfig {
+    pub topic: String,
+    pub msg_type: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ListenerConfigColor {
     pub topic: String,
     pub color: Color,
@@ -113,7 +119,7 @@ pub struct TermvizConfig {
     pub pointcloud2_topics: Vec<PointCloud2ListenerConfig>,
     pub pose_array_topics: Vec<PoseListenerConfig>,
     pub pose_stamped_topics: Vec<PoseListenerConfig>,
-    pub send_pose_topic: String,
+    pub send_pose_topics: Vec<SendPoseConfig>,
     pub target_framerate: i64,
     pub axis_length: f64,
     pub visible_area: Vec<f64>, //Borders of map from center in Meter
@@ -172,7 +178,10 @@ impl Default for TermvizConfig {
                 topic: "pointcloud2".to_string(),
                 use_rgb: false,
             }],
-            send_pose_topic: "initialpose".to_string(),
+            send_pose_topics: vec![SendPoseConfig {
+                topic: "initialpose".to_string(),
+                msg_type: "PoseWithCovarianceStamped".to_string(),
+            }],
             target_framerate: 30,
             axis_length: 0.5,
             visible_area: vec![-5., 5., -5., 5.],
@@ -190,6 +199,8 @@ impl Default for TermvizConfig {
                 (input::ZOOM_OUT.to_string(), "-".to_string()),
                 (input::INCREMENT_STEP.to_string(), "k".to_string()),
                 (input::DECREMENT_STEP.to_string(), "j".to_string()),
+                (input::NEXT.to_string(), "n".to_string()),
+                (input::PREVIOUS.to_string(), "b".to_string()),
                 (input::SHOW_HELP.to_string(), "h".to_string()),
                 (input::MODE_2.to_string(), "t".to_string()),
                 (input::MODE_3.to_string(), "i".to_string()),


### PR DESCRIPTION
Now Send Pose mode can support multiple topics of type Pose, PoseStamped and PoseWithCovarianceStamped.