### PR TITLE
Pin image pkg version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ colorgrad = "*"
 crossterm = { version = '0.23', features = ["event-stream"] }
 futures = "0.3"
 futures-timer = "3.0"
-image = "*"
+image = "0.24.6"
 nalgebra = ">=0.29.0"
 rand = "0.8.5"
 rosrust = "0.9.11"


### PR DESCRIPTION
Latest version(tried with 0.25.1) breaks compability, I get
```
root@2c7e3d1e50fa:/home/termviz# cargo build --release
    Updating crates.io index
   Compiling termviz v0.1.1 (/home/termviz)
error[E0308]: mismatched types
   --> src/app_modes/image_view.rs:134:50
    |
134 |                     let widget = Image::with_img(image.clone()).color_mode(ColorMode::Rgb);
    |                                  --------------- ^^^^^^^^^^^^^ expected `ImageBuffer<Rgba<u8>, Vec<u8>>`, found a different `ImageBuffer<Rgba<u8>, Vec<u8>>`
    |                                  |
    |                                  arguments to this function are incorrect
    |
    = note: `ImageBuffer<Rgba<u8>, Vec<u8>>` and `ImageBuffer<Rgba<u8>, Vec<u8>>` have similar names, but are actually distinct types
note: `ImageBuffer<Rgba<u8>, Vec<u8>>` is defined in crate `image`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/image-0.25.1/src/buffer.rs:656:1
    |
656 | pub struct ImageBuffer<P: Pixel, Container> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: `ImageBuffer<Rgba<u8>, Vec<u8>>` is defined in crate `image`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/image-0.24.9/src/buffer.rs:656:1
    |
656 | pub struct ImageBuffer<P: Pixel, Container> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `image` are being used?
note: associated function defined here
   --> /root/.cargo/git/checkouts/tui-image-37e59775b15e45e9/7aa600c/src/lib.rs:37:9
    |
37  |     pub fn with_img(img: RgbaImage) -> Image<'a> {
    |            ^^^^^^^^

For more information about this error, try `rustc --explain E0308`.
error: could not compile `termviz` (bin "termviz") due to 1 previous error
```