### PR TITLE
Make config backwards compatible and upgradable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -128,7 +128,7 @@ impl Default for TeleopConfig {
             increment_step: 0.1,
             cmd_vel_topic: "cmd_vel".to_string(),
             publish_cmd_vel_when_idle: true,
-            mode: TeleopMode::Classic,
+            mode: TeleopMode::default(),
             max_vel: 0.2,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,11 +2,11 @@ use crate::app_modes::input;
 use confy;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::io;
-use std::io::Write;
-use std::path::Path;
+use std::path::PathBuf;
 use strum_macros::Display;
 use tui::style::Color as TuiColor;
+
+const DEFAULT_PATH: &str = "/etc/termviz/termviz.yml";
 
 const fn default_int() -> i64 {
     0
@@ -244,48 +244,37 @@ impl Default for TermvizConfig {
     }
 }
 
-pub fn ask_store() -> bool {
-    let mut x = String::with_capacity(5);
-    print!("Store default config? (y|N): ");
-    let _ = io::stdout().flush();
-    io::stdin().read_line(&mut x).expect("Error reading input");
-    let x = x.strip_suffix("\n").unwrap();
-    match x.to_lowercase().as_str() {
-        "y" | "yes" => true,
-        _ => false,
-    }
-}
-
-pub fn get_config(config_path: Option<&String>) -> Result<TermvizConfig, confy::ConfyError> {
+/// Loads the config with the following priority:
+/// 1. from a custom path, if provided;
+/// 2. from the default user config path, if it exists;
+/// 3. from the default global config path, if it exists;
+/// 4. or with default values.
+pub fn get_config(custom_path: Option<&PathBuf>) -> Result<TermvizConfig, confy::ConfyError> {
+    let default_path = PathBuf::from(DEFAULT_PATH);
     let user_path = confy::get_configuration_file_path("termviz", "termviz")?;
 
-    // decide on which config path to load
-    let load_config_path = if config_path.is_some() {
-        // config path provided by command line arg
-        Path::new(config_path.unwrap())
-    } else if user_path.as_path().exists() {
-        // use user config if it exists
-        user_path.as_path()
+    let load_config_path = custom_path.unwrap_or_else(|| {
+        if user_path.exists() {
+            &user_path
+        } else {
+            &default_path
+        }
+    });
+
+    let cfg = if load_config_path.exists() {
+        println!("Loading config from: {:?}", load_config_path);
+        confy::load_path(&load_config_path)?
     } else {
-        // fallback to system config
-        Path::new("/etc/termviz/termviz.yml")
+        println!("No config found at {:?}, using defaults.", load_config_path);
+        TermvizConfig::default()
     };
 
-    let mut cfg = TermvizConfig::default();
-    if load_config_path.exists() {
-        println!("Loading config from: {:?}", load_config_path);
-        cfg = confy::load_path(load_config_path)?;
-    } else {
-        // no config found, generate default
-        println!("No config found, using default");
-        let store = ask_store();
-        if store {
-            let res = confy::store("termviz", "termviz", &cfg);
-            match res {
-                Ok(_) => println!("Stored default config at {:?}", user_path),
-                Err(e) => println!("Error storing default config: {:?}", e),
-            }
+    // Always update user config, unless a custom path was used.
+    if custom_path.is_none() {
+        match confy::store_path(&user_path.as_path(), &cfg) {
+            Ok(_) => println!("Updated {:?}", user_path),
+            Err(e) => println!("Error updating config at user path: {:?}", e),
         }
-    };
+    }
     Ok(cfg)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,15 +8,15 @@ use std::path::Path;
 use strum_macros::Display;
 use tui::style::Color as TuiColor;
 
-fn default_int() -> i64 {
+const fn default_int() -> i64 {
     0
 }
 
-fn default_map_threshold() -> i8 {
+const fn default_map_threshold() -> i8 {
     1
 }
 
-fn default_pose_length() -> f64 {
+const fn default_pose_length() -> f64 {
     0.2
 }
 
@@ -24,7 +24,7 @@ const fn default_teleop_max_vel() -> f64 {
     0.2
 }
 
-fn color_white() -> Color {
+const fn color_white() -> Color {
     Color {
         r: 255,
         g: 255,
@@ -32,7 +32,7 @@ fn color_white() -> Color {
     }
 }
 
-fn color_red() -> Color {
+const fn color_red() -> Color {
     Color { r: 255, g: 0, b: 0 }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,10 @@ fn default_pose_length() -> f64 {
     0.2
 }
 
+const fn default_teleop_max_vel() -> f64 {
+    0.2
+}
+
 fn color_white() -> Color {
     Color {
         r: 255,
@@ -95,12 +99,13 @@ pub struct MapListenerConfig {
     pub threshold: i8,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Display)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq, Display)]
 pub enum TeleopMode {
     // Node will keep speed button press only increment decrement
     Classic,
     // Speed will be reduced every iteration by one increment
     // To keep driving a button needs to be pressed every increment
+    #[default]
     Safe,
 }
 
@@ -110,7 +115,9 @@ pub struct TeleopConfig {
     pub increment_step: f64,
     pub cmd_vel_topic: String,
     pub publish_cmd_vel_when_idle: bool,
+    #[serde(default)]
     pub mode: TeleopMode,
+    #[serde(default = "default_teleop_max_vel")]
     pub max_vel: f64,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod transformation;
 use futures::{future::FutureExt, select, StreamExt};
 use futures_timer::Delay;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -36,7 +37,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let matches = Command::new("termviz")
         .about("ROS visualization on the terminal")
         .arg(
-            Arg::new("config").long_help("Optional YAML file with a custom termviz configuration."),
+            Arg::new("config")
+                .long_help("Optional YAML file with a custom termviz configuration.")
+                .value_parser(value_parser!(PathBuf)),
         )
         .arg(
             Arg::new("tf-wait-time")

--- a/src/pointcloud.rs
+++ b/src/pointcloud.rs
@@ -11,7 +11,6 @@ use rosrust;
 use rustros_tf;
 
 pub struct PointCloud2Listener {
-    pub config: PointCloud2ListenerConfig,
     pub points: Arc<RwLock<Vec<ColoredPoint>>>,
     _tf_listener: Arc<rustros_tf::TfListener>,
     _static_frame: String,
@@ -146,7 +145,6 @@ impl PointCloud2Listener {
         .unwrap();
 
         PointCloud2Listener {
-            config,
             points: occ_points,
             _tf_listener: tf_listener,
             _static_frame: static_frame.to_string(),


### PR DESCRIPTION
**Improve/simplify config loading**

Always update the user config path. This allows e.g. to automatically save new
fields (provided that they are added in a compatible way with `serde(default)`).

The `ask_store()` question is removed. Probably everyone answered yes anyway,
and it wasn't asked anymore after that first copy from the global default path.

**Remove config field that is never used**

**Make functions const that can be const**

**Make config backwards compatible**